### PR TITLE
Refactor Result handling and introduce Unit type

### DIFF
--- a/Fadi.Result.Tests/ResultProperties.cs
+++ b/Fadi.Result.Tests/ResultProperties.cs
@@ -6,6 +6,22 @@ public class ResultProperties
 	[TestCase]
 	public void WhenCreatedFromError()
 	{
+		Result<Unit> result = Result.FromError(new ResultError("error"));
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(result.IsSuccess, Is.False);
+			Assert.That(result.Entity, Is.InstanceOf<Unit>());
+			Assert.That(result.IsDefined, Is.True);
+			Assert.That(result.SuccessMessage, Is.Null);
+			Assert.That(result.Error, Is.Not.Null);
+			Assert.That(result.Error, Is.InstanceOf<ResultError>());
+		});
+	}
+
+	[TestCase]
+	public void WhenCreatedFromErrorGeneric()
+	{
 		Result<DummyEntity> result = Result<DummyEntity>.FromError(new ResultError("error"));
 
 		Assert.Multiple(() =>
@@ -20,7 +36,7 @@ public class ResultProperties
 	}
 
 	[TestCase]
-	public void WhenCreatedFromSuccess()
+	public void WhenCreatedFromSuccessGeneric()
 	{
 		Result<DummyEntity> result = Result<DummyEntity>.FromSuccess(new DummyEntity());
 
@@ -36,10 +52,10 @@ public class ResultProperties
 	}
 
 	[TestCase]
-	public void WhenCreatedFromSuccessWithMessage()
+	public void WhenCreatedFromSuccessWithMessageGeneric()
 	{
 		Result<DummyEntity> result =
-			Result<DummyEntity>.FromSuccessWithMessage(new DummyEntity(), "success");
+			Result<DummyEntity>.FromSuccess(new DummyEntity(), "success");
 
 		Assert.Multiple(() =>
 		{
@@ -55,8 +71,7 @@ public class ResultProperties
 	[TestCase]
 	public void WhenDefined()
 	{
-		Result result = new();
-
+		Result<Unit> result = default;
 		Assert.Multiple(() =>
 		{
 			Assert.That(result.IsSuccess, Is.False);
@@ -68,7 +83,7 @@ public class ResultProperties
 	}
 
 	[TestCase]
-	public void WhenDefinedGenric()
+	public void WhenDefinedGeneric()
 	{
 		Result<DummyEntity> result = new();
 

--- a/Fadi.Result.Tests/ResultSerialization.cs
+++ b/Fadi.Result.Tests/ResultSerialization.cs
@@ -28,9 +28,9 @@ public static class ResultSerializations
 		public void ReturnsTrueForSuccessfulResult()
 		{
 			var successful = Result.FromSuccess("Dummy message");
-			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful));
+			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful, _jsonOptions));
 
-			var response = JsonSerializer.Deserialize<Result>(serializedData);
+			var response = JsonSerializer.Deserialize<Result<Unit>>(serializedData, _jsonOptions);
 
 			Assert.That(response.IsSuccess, Is.True);
 		}
@@ -39,9 +39,9 @@ public static class ResultSerializations
 		public void ReturnsTrueForSuccessfulGenericResult()
 		{
 			var successful = Result<ModelTest>.FromSuccess(new ModelTest("Dummy value"));
-			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful));
+			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful, _jsonOptions));
 
-			var response = JsonSerializer.Deserialize<Result<ModelTest>>(serializedData);
+			var response = JsonSerializer.Deserialize<Result<ModelTest>>(serializedData, _jsonOptions);
 
 			Assert.That(response.IsSuccess, Is.True);
 		}
@@ -77,7 +77,7 @@ public static class ResultSerializations
 			var successful = Result.FromSuccess("Dummy message");
 			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful));
 
-			var response = JsonSerializer.Deserialize<Result>(serializedData);
+			var response = JsonSerializer.Deserialize<Result<Unit>>(serializedData);
 
 			Assert.That(response.SuccessMessage, Is.EqualTo("Dummy message"));
 		}
@@ -88,7 +88,7 @@ public static class ResultSerializations
 			var successful = Result.FromSuccess("Dummy message");
 			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful));
 
-			var response = JsonSerializer.Deserialize<Result<string>>(serializedData);
+			var response = JsonSerializer.Deserialize<Result<Unit>>(serializedData);
 			Assert.That(response.SuccessMessage, Is.EqualTo("Dummy message"));
 		}
 
@@ -105,7 +105,7 @@ public static class ResultSerializations
 		[Test]
 		public void NotEmptyOnDeserializingEntityResultUsingFromSuccessWithMessage()
 		{
-			var successful = Result<Guid>.FromSuccessWithMessage(Guid.NewGuid(), "Dummy message");
+			var successful = Result<Guid>.FromSuccess(Guid.NewGuid(), "Dummy message");
 			byte[] serializedData = Encoding.Default.GetBytes(JsonSerializer.Serialize(successful));
 
 			var response = JsonSerializer.Deserialize<Result<string>>(serializedData);

--- a/Fadi.Result/Errors/ExceptionError.cs
+++ b/Fadi.Result/Errors/ExceptionError.cs
@@ -5,24 +5,24 @@ namespace Fadi.Result.Errors;
 
 public record ExceptionError : ResultError
 {
-  public string TraceId { get; }
-  public string SpanId { get; }
-  public DateTimeOffset TimeStamp { get; }
+	public string TraceId { get; }
+	public string SpanId { get; }
+	public DateTimeOffset TimeStamp { get; }
 
-  public ExceptionError(string message)
-      : base(message)
-  {
-    TraceId = Activity.Current?.TraceId.ToString() ?? "";
-    SpanId = Activity.Current?.SpanId.ToString() ?? "";
-    TimeStamp = DateTimeOffset.UtcNow;
-  }
+	public ExceptionError(string message)
+			: base(message)
+	{
+		TraceId = Activity.Current?.TraceId.ToString() ?? "";
+		SpanId = Activity.Current?.SpanId.ToString() ?? "";
+		TimeStamp = DateTimeOffset.UtcNow;
+	}
 
-  [JsonConstructor]
-  public ExceptionError(string message, string traceId, string spanId, DateTimeOffset timeStamp)
-      : base(message)
-  {
-    TraceId = traceId;
-    SpanId = spanId;
-    TimeStamp = timeStamp;
-  }
+	[JsonConstructor]
+	public ExceptionError(string message, string traceId, string spanId, DateTimeOffset timeStamp)
+			: base(message)
+	{
+		TraceId = traceId;
+		SpanId = spanId;
+		TimeStamp = timeStamp;
+	}
 }

--- a/Fadi.Result/IResult.cs
+++ b/Fadi.Result/IResult.cs
@@ -1,18 +1,23 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿namespace Fadi.Result;
 
-namespace Fadi.Result;
-
-public interface IResult
+public interface IResult<T>
 {
 	bool IsSuccess { get; }
 	bool IsFailed { get; }
 	bool IsDefined { get; }
-	string SuccessMessage { get; }
-	IResultError? Error { get; }
-}
 
-public interface IResult<out TEntity> : IResult
-{
-	[AllowNull]
-	TEntity Entity { get; }
+	/// <summary>
+	/// Optional success message
+	/// </summary>
+	string? SuccessMessage { get; }
+
+	/// <summary>
+	/// Polymorphic error
+	/// </summary>
+	IResultError? Error { get; }
+
+	/// <summary>
+	/// the value (Unit if none)
+	/// </summary>
+	T Entity { get; }
 }

--- a/Fadi.Result/Unit.cs
+++ b/Fadi.Result/Unit.cs
@@ -1,0 +1,21 @@
+﻿namespace Fadi.Result;
+
+public readonly struct Unit : IEquatable<Unit>
+{
+	/// <summary>The single Unit value (analogous to `void`).</summary>
+	public static Unit Value { get; } = default;
+	public bool Equals(Unit other) => true;
+	public override bool Equals(object? obj) => obj is Unit;
+	public override int GetHashCode() => 0;
+	public override string ToString() => "()";
+
+	public static bool operator ==(Unit left, Unit right)
+	{
+		return left.Equals(right);
+	}
+
+	public static bool operator !=(Unit left, Unit right)
+	{
+		return !(left == right);
+	}
+}


### PR DESCRIPTION
Refactor Result handling and introduce Unit type

Updated ResultProperties to support generic types with new test cases. Enhanced serialization in ResultSerialization to use _jsonOptions and handle Result<Unit>. Reformatted ExceptionError for consistency. Modified IResult interface for generics and nullable properties. Refactored Result and Result<TEntity> structs for streamlined success/failure logic. Introduced new Unit struct as a placeholder type.