### PR TITLE
Refactor Result tests and fix naming errors

### DIFF
--- a/Fadi.Result.Tests/ResultProperties.cs
+++ b/Fadi.Result.Tests/ResultProperties.cs
@@ -3,83 +3,139 @@ public class ResultProperties
 {
 	public record DummyEntity { }
 
-	[TestCase]
-	public void WhenCreatedFromError()
+	public class NonGeneric
 	{
-		Result<DummyEntity> result = Result<DummyEntity>.FromError(new ResultError("error"));
-
-		Assert.Multiple(() =>
+		[TestCase]
+		public void WhenCreatedFromError()
 		{
-			Assert.That(result.IsSuccess, Is.False);
-			Assert.That(result.Entity, Is.Null);
-			Assert.That(result.IsDefined, Is.True);
-			Assert.That(result.SuccessMessage, Is.Null);
-			Assert.That(result.Error, Is.Not.Null);
-			Assert.That(result.Error, Is.InstanceOf<ResultError>());
-		});
+			Result result = Result.FromError(new ResultError("error"));
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.False);
+				Assert.That(result.IsDefined, Is.True);
+				Assert.That(result.SuccessMessage, Is.Null);
+				Assert.That(result.Error, Is.Not.Null);
+				Assert.That(result.Error, Is.InstanceOf<ResultError>());
+				Assert.That(result.Error?.Message, Is.EqualTo("error"));
+			});
+		}
+
+		[TestCase]
+		public void WhenCreatedFromSuccess()
+		{
+			Result result = Result.FromSuccess();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.True);
+				Assert.That(result.IsFailed, Is.False);
+				Assert.That(result.IsDefined, Is.True);
+				Assert.That(result.Error, Is.Null);
+				Assert.That(result.SuccessMessage, Is.Null);
+			});
+		}
+
+		[TestCase]
+		public void WhenCreatedFromSuccessWithSuccessMessage()
+		{
+			Result result = Result.FromSuccess("success");
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.True);
+				Assert.That(result.IsFailed, Is.False);
+				Assert.That(result.IsDefined, Is.True);
+				Assert.That(result.Error, Is.Null);
+				Assert.That(result.SuccessMessage, Is.EqualTo("success"));
+			});
+		}
+
+		[TestCase]
+		public void WhenDefined()
+		{
+			Result result = new();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.False);
+				Assert.That(result.IsFailed, Is.False);
+				Assert.That(result.IsDefined, Is.False);
+				Assert.That(result.Error, Is.Null);
+				Assert.That(result.SuccessMessage, Is.Null);
+			});
+		}
 	}
 
-	[TestCase]
-	public void WhenCreatedFromSuccess()
+	public class Generic
 	{
-		Result<DummyEntity> result = Result<DummyEntity>.FromSuccess(new DummyEntity());
-
-		Assert.Multiple(() =>
+		[TestCase]
+		public void WhenCreatedFromError()
 		{
-			Assert.That(result.IsSuccess, Is.True);
-			Assert.That(result.IsFailed, Is.False);
-			Assert.That(result.IsDefined, Is.True);
-			Assert.That(result.Entity, Is.Not.Null);
-			Assert.That(result.Entity, Is.InstanceOf<DummyEntity>());
-			Assert.That(result.SuccessMessage, Is.Null);
-		});
-	}
+			Result<DummyEntity> result = Result<DummyEntity>.FromError(new ResultError("error"));
 
-	[TestCase]
-	public void WhenCreatedFromSuccessWithMessage()
-	{
-		Result<DummyEntity> result =
-			Result<DummyEntity>.FromSuccessWithMessage(new DummyEntity(), "success");
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.False);
+				Assert.That(result.IsFailed, Is.True);
+				Assert.That(result.Entity, Is.Null);
+				Assert.That(result.IsDefined, Is.True);
+				Assert.That(result.SuccessMessage, Is.Null);
+				Assert.That(result.Error, Is.Not.Null);
+				Assert.That(result.Error, Is.InstanceOf<ResultError>());
+				Assert.That(result.Error?.Message, Is.EqualTo("error"));
+			});
+		}
 
-		Assert.Multiple(() =>
+		[TestCase]
+		public void WhenCreatedFromSuccess()
 		{
-			Assert.That(result.IsSuccess, Is.True);
-			Assert.That(result.IsFailed, Is.False);
-			Assert.That(result.IsDefined, Is.True);
-			Assert.That(result.Entity, Is.Not.Null);
-			Assert.That(result.Entity, Is.InstanceOf<DummyEntity>());
-			Assert.That(result.SuccessMessage, Is.Not.Null);
-		});
-	}
+			Result<DummyEntity> result = Result<DummyEntity>.FromSuccess(new DummyEntity());
 
-	[TestCase]
-	public void WhenDefined()
-	{
-		Result result = new();
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.True);
+				Assert.That(result.IsFailed, Is.False);
+				Assert.That(result.IsDefined, Is.True);
+				Assert.That(result.Entity, Is.Not.Null);
+				Assert.That(result.Entity, Is.InstanceOf<DummyEntity>());
+				Assert.That(result.Error, Is.Null);
+				Assert.That(result.SuccessMessage, Is.Null);
+			});
+		}
 
-		Assert.Multiple(() =>
+		[TestCase]
+		public void WhenCreatedFromSuccessWithSuccessMessage()
 		{
-			Assert.That(result.IsSuccess, Is.False);
-			Assert.That(result.IsFailed, Is.False);
-			Assert.That(result.IsDefined, Is.False);
-			Assert.That(result.Error, Is.Null);
-			Assert.That(result.SuccessMessage, Is.Null);
-		});
-	}
+			Result<DummyEntity> result =
+				Result<DummyEntity>.FromSuccessWithMessage(new DummyEntity(), "success");
 
-	[TestCase]
-	public void WhenDefinedGenric()
-	{
-		Result<DummyEntity> result = new();
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.True);
+				Assert.That(result.IsFailed, Is.False);
+				Assert.That(result.IsDefined, Is.True);
+				Assert.That(result.Entity, Is.Not.Null);
+				Assert.That(result.Entity, Is.InstanceOf<DummyEntity>());
+				Assert.That(result.Error, Is.Null);
+				Assert.That(result.SuccessMessage, Is.Not.Null);
+			});
+		}
 
-		Assert.Multiple(() =>
+		[TestCase]
+		public void WhenDefinedGeneric()
 		{
-			Assert.That(result.IsSuccess, Is.False);
-			Assert.That(result.IsFailed, Is.False);
-			Assert.That(result.IsDefined, Is.False);
-			Assert.That(result.Error, Is.Null);
-			Assert.That(result.Entity, Is.Null);
-			Assert.That(result.SuccessMessage, Is.Null);
-		});
+			Result<DummyEntity> result = new();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(result.IsSuccess, Is.False);
+				Assert.That(result.IsFailed, Is.False);
+				Assert.That(result.IsDefined, Is.False);
+				Assert.That(result.Error, Is.Null);
+				Assert.That(result.Entity, Is.Null);
+				Assert.That(result.SuccessMessage, Is.Null);
+			});
+		}
 	}
 }

--- a/Fadi.Result/Errors/UnauthentectedError.cs
+++ b/Fadi.Result/Errors/UnauthentectedError.cs
@@ -1,3 +1,3 @@
 ﻿namespace Fadi.Result.Errors;
 
-public sealed record UnauthentectedError(string Message = "401") : ResultError(Message);
+public sealed record UnauthenticatedError(string Message = "401") : ResultError(Message);

--- a/Fadi.Result/IResult.cs
+++ b/Fadi.Result/IResult.cs
@@ -7,7 +7,7 @@ public interface IResult
 	bool IsSuccess { get; }
 	bool IsFailed { get; }
 	bool IsDefined { get; }
-	string SuccessMessage { get; }
+	string? SuccessMessage { get; }
 	IResultError? Error { get; }
 }
 

--- a/Fadi.Result/Serialization/DefaultResultErrorPolymorphicResolver.cs
+++ b/Fadi.Result/Serialization/DefaultResultErrorPolymorphicResolver.cs
@@ -14,7 +14,7 @@ public class DefaultResultErrorPolymorphicResolver : IResultErrorPolymorphicReso
 		new(typeof(GenericError), nameof(GenericError)),
 		new(typeof(NotFoundError), nameof(NotFoundError)),
 		new(typeof(ValidationErrorResult), nameof(ValidationErrorResult)),
-		new(typeof(UnauthentectedError), nameof(UnauthentectedError)),
+		new(typeof(UnauthenticatedError), nameof(UnauthenticatedError)),
 		new(typeof(UnauthorizedError), nameof(UnauthorizedError)),
 		new(typeof(ResultError), nameof(ResultError)),
 	];

--- a/Fadi.Result/Serialization/PolymorphicTypeResolver.cs
+++ b/Fadi.Result/Serialization/PolymorphicTypeResolver.cs
@@ -26,7 +26,7 @@ public class PolymorphicTypeResolver : DefaultJsonTypeInfoResolver
 					new JsonDerivedType(typeof(GenericError), nameof(GenericError)),
 					new JsonDerivedType(typeof(NotFoundError), nameof(NotFoundError)),
 					new JsonDerivedType(typeof(ValidationErrorResult), nameof(ValidationErrorResult)),
-					new JsonDerivedType(typeof(UnauthentectedError), nameof(UnauthentectedError)),
+					new JsonDerivedType(typeof(UnauthenticatedError), nameof(UnauthenticatedError)),
 					new JsonDerivedType(typeof(UnauthorizedError), nameof(UnauthorizedError)),
 				}
 			};


### PR DESCRIPTION
Refactor Result tests and fix naming errors

- Updated `ResultProperties.cs` to refactor tests for the `Result` class, removing generic usage and adding new test methods for error and success scenarios.
- Corrected the record name from `UnauthentectedError` to `UnauthenticatedError` in `UnauthentectedError.cs`.
- Modified `IResult.cs` to change `SuccessMessage` to a nullable string.
- Enhanced the `Result` and `Result<TEntity>` structs in `Result.cs` with new constructors and refined logic for success and failure.
- Updated references in `DefaultResultErrorPolymorphicResolver.cs` and `PolymorphicTypeResolver.cs` to use the corrected error name.